### PR TITLE
feat: プロフィール画像表示

### DIFF
--- a/backend/app/controllers/api/v1/profiles_controller.rb
+++ b/backend/app/controllers/api/v1/profiles_controller.rb
@@ -26,6 +26,6 @@ class Api::V1::ProfilesController < ApplicationController
   private
 
   def default_params
-    [:name, :bio, :x_twitter, :instagram, :facebook, :linkedin, :tiktok, :youtube, :website]
+    [:name, :bio, :x_twitter, :instagram, :facebook, :linkedin, :tiktok, :youtube, :website, :avatar_url]
   end
 end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -25,7 +25,8 @@ class Api::V1::UsersController < ApplicationController
             :linkedin,
             :tiktok,
             :youtube,
-            :website
+            :website,
+            :avatar_url
           ]
         }
       }

--- a/backend/spec/requests/api/v1/profiles_controller_spec.rb
+++ b/backend/spec/requests/api/v1/profiles_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Api::V1::ProfilesController do
 
         json = response.parsed_body
 
-        expect(json.size).to eq(9)
+        expect(json.size).to eq(10)
         expect(json['name']).to eq('ノイマン')
         expect(json['bio']).to eq('あらゆる学問に精通しています。コンピュータの開発に貢献しました。')
         expect(json['x_twitter']).to eq('neumann-1903')
@@ -47,6 +47,7 @@ RSpec.describe Api::V1::ProfilesController do
         expect(json['tiktok']).to eq('neumann-1903')
         expect(json['youtube']).to eq('neumann-1903')
         expect(json['website']).to eq('https://neuman.com')
+        expect(json['avatar_url']).to eq('https://lh4.googleusercontent.com/photo.jpg')
       end
     end
 
@@ -82,7 +83,7 @@ RSpec.describe Api::V1::ProfilesController do
 
         json = response.parsed_body
 
-        expect(json.size).to eq(9)
+        expect(json.size).to eq(10)
         expect(json['name']).to eq('こんどう ひろき')
         expect(json['bio']).to eq('Youtubeしてます')
         expect(json['x_twitter']).to eq('hiroki-1998')
@@ -92,6 +93,7 @@ RSpec.describe Api::V1::ProfilesController do
         expect(json['tiktok']).to eq('hiroki-1998')
         expect(json['youtube']).to eq('hiroki_1998')
         expect(json['website']).to eq('https://hiroki.com')
+        expect(json['avatar_url']).to eq('https://lh4.googleusercontent.com/photo.jpg')
       end
     end
 

--- a/backend/spec/requests/api/v1/users_controller_spec.rb
+++ b/backend/spec/requests/api/v1/users_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::V1::UsersController do
         json = response.parsed_body
 
         expect(json.size).to eq(3)
-        expect(json['profile'].size).to eq(9)
+        expect(json['profile'].size).to eq(10)
 
         expect(json['name']).to eq('neumann')
         expect(json['email']).to be_present
@@ -48,6 +48,7 @@ RSpec.describe Api::V1::UsersController do
         expect(json['profile']['tiktok']).to eq('neumann-1903')
         expect(json['profile']['youtube']).to eq('neumann-1903')
         expect(json['profile']['website']).to eq('https://neuman.com')
+        expect(json['profile']['avatar_url']).to eq('https://lh4.googleusercontent.com/photo.jpg')
       end
 
       it 'ログインユーザ自身が別のユーザ詳細を取得しようとしても自身が返る' do

--- a/frontend/neumann-client/src/app/(main)/(public)/users/[slug]/layout.tsx
+++ b/frontend/neumann-client/src/app/(main)/(public)/users/[slug]/layout.tsx
@@ -21,6 +21,7 @@ import {
   youtubeAccountURL,
 } from '@/utils/profileURL'
 import { range } from '@/utils/range'
+import Image from 'next/image'
 
 type SlugsProps = {
   slug: string
@@ -71,8 +72,24 @@ export default async function ProfileLayout({ children, params }: { children: Re
   return (
     <section className='space-y-8'>
       <div className='md:flex  md:space-x-4 md:space-y-0 space-y-4'>
-        <div className='w-16 h-16 rounded-lg py-6 shadow sub-bg-color text-xs font-medium text-center dark:border dark:border-gray-600'>
-          (,,0‸0,,)
+        <div className='w-16 h-16 flex justify-center items-center rounded-lg shadow sub-bg-color text-xs font-medium text-center dark:border dark:border-gray-600'>
+          {res.avatar_url ? (
+            <Image
+              width={64}
+              height={64}
+              src={res.avatar_url}
+              alt={`${res.name}のプロフィール画像`}
+              sizes='
+                        50vw,
+                        (min-width: 768px) 33vw,
+                        (min-width: 1024px) 25vw,
+                        (min-width: 1280px) 20vw
+                      '
+              className='rounded-lg object-cover'
+            />
+          ) : (
+            '(,,0‸0,,)'
+          )}
         </div>
         <div className='max-w-80 space-y-2'>
           <h2 className='font-bold'>{res.name}</h2>

--- a/frontend/neumann-client/src/components/common/Header/Avatar.tsx
+++ b/frontend/neumann-client/src/components/common/Header/Avatar.tsx
@@ -3,6 +3,7 @@ import { useUser } from '@/contexts/UserContext'
 import { useLogout } from '@/hooks/useLogout'
 import { isLoggedInBefore } from '@/utils/localStorage'
 import { AnimatePresence, motion } from 'framer-motion'
+import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 import HurtIcon from '../icon/HurtIcon'
@@ -65,7 +66,23 @@ export default function Avatar() {
             onClick={handleClick}
             className='w-12 h-12 rounded-lg shadow sub-bg-color text-xs font-medium text-center dark:border dark:border-gray-600'
           >
-            (,,0‸0,,)
+            {user.profile.avatar_url ? (
+              <Image
+                width={48}
+                height={48}
+                src={user.profile.avatar_url}
+                alt={`${user.profile.name}のプロフィール画像`}
+                sizes='
+                          50vw,
+                          (min-width: 768px) 33vw,
+                          (min-width: 1024px) 25vw,
+                          (min-width: 1280px) 20vw
+                        '
+                className='rounded-lg object-cover'
+              />
+            ) : (
+              '(,,0‸0,,)'
+            )}
           </button>
           <AnimatePresence>
             {isOpen && (

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/profile.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/profile.ts
@@ -14,6 +14,7 @@ type Response = {
   tiktok: string
   youtube: string
   website: string
+  avatar_url: string
 }
 
 type UpdateParams = {

--- a/frontend/neumann-client/src/types/user.ts
+++ b/frontend/neumann-client/src/types/user.ts
@@ -11,5 +11,6 @@ export type User = {
     tiktok: string
     youtube: string
     website: string
+    avatar_url: string
   }
 }


### PR DESCRIPTION
### やりたかったこと

プロフィール画像の表示

### やったこと

- ユーザ、プロフィールコントローラからavatar_urlを返すように変更（この変更ではGoogleログイン時に受け取ったプロフィール画像を表示するのみなので、通常のログインフローのユーザはプロフィール画像が表示されない）
- 編集でavatar_urlを更新できるようにした（リクエストのみ）
- フロントで受け取ったavatar_urlをImageコンポーネントに渡して画像を表示するように変更


### やらなかったこと

- 通常のユーザプロフィール画像設定、今後実装予定
- フロントエンドからavatar_urlの更新、今度実装予定

### ユーザ視点での変更

- Google認証を行ったユーザは設定されているプロフィール画像が表示される

### 影響範囲

ユーザ、プロフィールコントローラ、フロントエンドでのプロフィール画像を表示する箇所

### 動作確認観点

- RSpec
- 通常のユーザでログイン、メニューボタン、プロフィールページ確認
- Google認証のユーザでログイン、メニューボタン、プロフィールページ確認

### issue


### その他

