### PR TITLE
fix: google認証ユーザ検索

### DIFF
--- a/backend/app/controllers/api/v1/google_oauth2_controller.rb
+++ b/backend/app/controllers/api/v1/google_oauth2_controller.rb
@@ -28,6 +28,7 @@ class Api::V1::GoogleOauth2Controller < ApplicationController
     user_info = account.info(oauth_params)
     {
       provider: 'google',
+      sub: user_info['sub'],
       name: user_info['name'],
       email: user_info['email'],
       picture: user_info['picture']

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -35,7 +35,8 @@ class Api::V1::UsersController < ApplicationController
 
   def create
     user = User.create!(create_params)
-    user.create_profile
+    user.create_provider!(kind: Provider.kinds['default'])
+    user.create_profile!
 
     render status: :created, json: login_response_with_cookie(user)
   end

--- a/backend/app/models/provider.rb
+++ b/backend/app/models/provider.rb
@@ -1,0 +1,11 @@
+class Provider < ApplicationRecord
+  belongs_to :user
+
+  enum :kind, {
+    default: 0,
+    google: 1
+  }, validate: true
+
+  validates :kind, presence: true
+  validates :uid, length: { maximum: 150 }, uniqueness: true
+end

--- a/backend/config/locales/models/ja.yml
+++ b/backend/config/locales/models/ja.yml
@@ -8,7 +8,9 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: 確認用パスワード
-        provider: 認証サービス名
+      provider:
+        kind: 認証サービス名
+        uid: ユーザID
       profile:
         name: 表示名
         bio: 自己紹介
@@ -45,7 +47,9 @@ ja:
             password:
               invalid: は半角英数字、ハイフン、アンダーバーで入力してください
               password_too_long: は72文字以内で入力してください
-            provider:
+        provider:
+          attributes:
+            kind:
               inclusion: が範囲外の値です
         profile:
           attributes:

--- a/backend/db/migrate/20240513053535_remove_provider_from_user.rb
+++ b/backend/db/migrate/20240513053535_remove_provider_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveProviderFromUser < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :provider, :integer
+  end
+end

--- a/backend/db/migrate/20240513053814_create_providers.rb
+++ b/backend/db/migrate/20240513053814_create_providers.rb
@@ -1,0 +1,13 @@
+class CreateProviders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :providers do |t|
+      t.belongs_to :user, foreign_key: true
+      t.integer :kind, null: false, default: 0
+      t.string :uid, null: false, default: ''
+
+      t.timestamps
+    end
+
+    add_index :providers, :uid, unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_053814) do
     t.string "uid", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_providers_on_uid", unique: true
     t.index ["user_id"], name: "index_providers_on_user_id"
   end
 

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_02_024752) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_13_053814) do
   create_table "books", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.string "img_url", default: "", null: false
@@ -54,6 +54,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_024752) do
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
+  create_table "providers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "kind", default: 0, null: false
+    t.string "uid", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_providers_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "email", default: "", null: false
@@ -61,11 +70,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_024752) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "current_token_version"
-    t.integer "provider", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
   end
 
   add_foreign_key "likes", "users"
   add_foreign_key "profiles", "users"
+  add_foreign_key "providers", "users"
 end

--- a/backend/spec/factories/providers.rb
+++ b/backend/spec/factories/providers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :provider do
+    kind { Provider.kinds['default'] }
+    uid { '12345678' }
+  end
+end

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     name { 'neumann' }
     email { FFaker::Internet.email }
     password { '1111111q' }
-    provider { User.providers[:default] }
 
     created_at { Time.zone.now }
     updated_at { Time.zone.now }

--- a/backend/spec/models/provider_spec.rb
+++ b/backend/spec/models/provider_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Provider do
+  let(:user) { FactoryBot.build(:user) }
+  let(:provider_default) { FactoryBot.build(:provider, user:) }
+  let(:provider_google) { FactoryBot.build(:provider, kind: described_class.kinds['google'], user:) }
+
+  describe 'validation' do
+    context 'kind' do
+      it '登録可能' do
+        expect(provider_default).to be_valid
+        expect(provider_default.kind).to eq('default')
+      end
+
+      it 'google認証で登録可能' do
+        expect(provider_google).to be_valid
+        expect(provider_google.kind).to eq('google')
+      end
+
+      it 'nilの場合エラー' do
+        expect { FactoryBot.create(:provider, kind: nil, user:) }.to(raise_error do |error|
+          expect(error).to be_a(ActiveRecord::RecordInvalid)
+          expect(error.message).to eq '認証サービス名が範囲外の値です, 認証サービス名を入力してください'
+        end)
+      end
+
+      it '範囲外の値の場合エラー' do
+        default_user_provider = FactoryBot.build(:provider, kind: 99, user:)
+
+        expect(default_user_provider).not_to be_valid
+        expect(default_user_provider.errors.full_messages_for(:kind).first).to eq('認証サービス名が範囲外の値です')
+      end
+    end
+
+    context 'uid' do
+      it '登録可能' do
+        expect(provider_default).to be_valid
+        expect(provider_default.uid).to eq('12345678')
+      end
+
+      it '重複したは登録不可' do
+        FactoryBot.create(:provider, user:)
+        default_user_provider = FactoryBot.build(:provider, user:)
+        expect(default_user_provider).not_to be_valid
+        expect(default_user_provider.errors.full_messages_for(:uid).first).to eq('ユーザIDはすでに存在します')
+      end
+
+      it 'nilの場合エラー' do
+        expect do
+          FactoryBot.create(:provider, uid: nil, user:)
+        end.to raise_error(ActiveRecord::NotNullViolation)
+      end
+
+      it '空文字入力可能' do
+        default_user_provider = FactoryBot.build(:provider, uid: '', user:)
+        expect(default_user_provider).to be_valid
+        expect(default_user_provider.uid).to eq('')
+      end
+
+      it 'uidが151文字以上の場合エラー' do
+        default_user_provider = FactoryBot.build(:provider, uid: 'a' * 151, user:)
+
+        expect(default_user_provider).not_to be_valid
+        expect(default_user_provider.errors.full_messages_for(:uid).first).to eq('ユーザIDは150文字以内で入力してください')
+      end
+    end
+  end
+end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -331,6 +331,23 @@ RSpec.describe User do
       end
     end
 
+    context 'validate_user_created_email' do
+      it 'google認証以外でメールアドレスが使用済みの場合エラー' do
+        expect { described_class.validate_user_created_email(user_default_signed_up.user.email) }.to(raise_error do |error|
+          expect(error).to be_a(Constants::Exceptions::SignUp)
+          expect(error.message).to eq 'Google認証以外の方法でアカウント作成済みです。'
+        end)
+      end
+
+      it 'google認証によって作成されたユーザの場合は何も返さない' do
+        expect(described_class.validate_user_created_email(user_google_signed_up.user.email)).to be_nil
+      end
+
+      it '存在しないメールアドレスの場合何も返さない' do
+        expect(described_class.validate_user_created_email('no-exsist@no-exsist,com')).to be_nil
+      end
+    end
+
     context 'from_google_oauth2' do
       it 'google認証によるアカウント作成可能' do
         u = described_class.from_google_oauth2(google_oauth2_params)

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -5,21 +5,23 @@ RSpec.describe User do
   let(:google_oauth2_params) do
     {
       provider: 'google',
+      sub: '12345678',
       name: 'John Smith',
       email: 'john@gmail.com',
       picture: 'https://lh4.googleusercontent.com/photo.jpg'
     }
   end
-  let(:user_default_signed_up) { FactoryBot.create(:user, email: google_oauth2_params[:email]) }
-  let(:user_google_signed_up) do
+  let(:user_default) { FactoryBot.create(:user, email: google_oauth2_params[:email]) }
+  let(:user_default_signed_up) { FactoryBot.create(:provider, uid: '12345678', user: user_default) }
+  let(:user_google) do
     FactoryBot.create(
       :user,
       name: SecureRandom.uuid,
       email: google_oauth2_params[:email],
-      password: described_class.auto_create_password,
-      provider: described_class.providers[:google]
+      password: described_class.auto_create_password
     )
   end
+  let(:user_google_signed_up) { FactoryBot.create(:provider, kind: Provider.kinds['google'], user: user_google) }
 
   it '有効なファクトリを持つこと' do
     expect(user).to be_valid
@@ -160,32 +162,6 @@ RSpec.describe User do
 
         user_searched.update!(name: 'hiroki')
         expect(user_searched.name).to eq('hiroki')
-      end
-    end
-
-    context 'provider' do
-      it '登録可能' do
-        expect(user).to be_valid
-        expect(user.provider).to eq('default')
-      end
-
-      it 'google_oauth2で登録可能' do
-        u = FactoryBot.build(:user, provider: 1)
-        expect(u).to be_valid
-        expect(u.provider).to eq('google')
-      end
-
-      it 'nilの場合エラー' do
-        expect { FactoryBot.create(:user, provider: nil) }.to(raise_error do |error|
-          expect(error).to be_a(ActiveRecord::RecordInvalid)
-          expect(error.message).to eq '認証サービス名が範囲外の値です, 認証サービス名を入力してください'
-        end)
-      end
-
-      it '範囲外の値の場合エラー' do
-        u = FactoryBot.build(:user, provider: 99)
-        expect(u).not_to be_valid
-        expect(u.errors.full_messages_for(:provider).first).to eq('認証サービス名が範囲外の値です')
       end
     end
   end
@@ -359,7 +335,7 @@ RSpec.describe User do
       it 'google認証によるアカウント作成可能' do
         u = described_class.from_google_oauth2(google_oauth2_params)
         expect(u).to be_valid
-        expect(u.provider).to eq('google')
+        expect(u.provider.kind).to eq('google')
       end
 
       it 'google認証によるログイン可能' do
@@ -369,11 +345,11 @@ RSpec.describe User do
 
         u = described_class.from_google_oauth2(google_oauth2_params)
         expect(u).to be_valid
-        expect(u.provider).to eq('google')
+        expect(u.provider.kind).to eq('google')
         expect(u.email).to eq(google_oauth2_params[:email])
       end
 
-      it 'google認証以外のアカウント作成の場合、google認証によるログイン不可' do
+      it 'google認証以外のアカウント作成でuidが重複する場合、google認証によるログイン不可' do
         user_all_count = described_class.all.size
         user_default_signed_up
 

--- a/backend/spec/services/oauth2/google/account_spec.rb
+++ b/backend/spec/services/oauth2/google/account_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Oauth2::Google::Account, type: :service do
         user_info = google_account_mocked.info(verifier_params)
 
         expect(user_info.size).to eq(7)
-        expect(user_info['sub']).to eq('123')
+        expect(user_info['sub']).to eq('12345678')
         expect(user_info['name']).to eq('neumann')
         expect(user_info['given_name']).to eq('neumann')
         expect(user_info['picture']).to eq('https://lh3.googleusercontent.com/a/test')

--- a/backend/spec/support/helpers/oauth2_helper.rb
+++ b/backend/spec/support/helpers/oauth2_helper.rb
@@ -24,7 +24,7 @@ module Oauth2Helper
       client_authorized_mock = instance_double(OAuth2::AccessToken)
       code_decoded = 'fake_code'
       user_info = {
-        'sub' => '123',
+        'sub' => '12345678',
         'name' => 'neumann',
         'given_name' => 'neumann',
         'picture' => 'https://lh3.googleusercontent.com/a/test',


### PR DESCRIPTION
### やりたかったこと

Google認証で作成されたユーザ検索をGmailではなく、uidで行うようにする

### やったこと

- usersテーブルからproviderカラムを削除
- providersテーブルを作成してそこでproviderのtypeとuidを管理するように変更
- それに合わせてモデル、コントローラ、テストを修正


### やらなかったこと

- 特になし

### ユーザ視点での変更

Google認証で登録したユーザがemailアドレスの変更を行なっても引き続きGoogle認証が行えるようになった
そして、Gmail自体の変更（滅多に発生しないと思うが...）があっても引き続きログインが可能な状態になった

### 影響範囲

ユーザログイン、新規作成、アカウント設定の変更

### 動作確認観点

今回の変更箇所で影響を受けそうな箇所に対してどのような確認をしたか教えて下さい、テストケース等があればURLの記載をお願いします。（この説明は記載する際に削除して下さい）
チェックリスト形式でここに記載しても良いです。

 - [x] RSpec
 - [x] 通常のユーザ新規作成・ログイン・ログアウトフロー
 - [x] Googleアカウントユーザ新規作成・ログイン・ログアウトフロー
 - [x] Googleアカウントユーザ登録済みのメールアドレスを変更してのログイン・ログアウトフロー

### issue


### その他

