### PR TITLE
fix: カラム名変更

### DIFF
--- a/backend/app/controllers/api/v1/profiles_controller.rb
+++ b/backend/app/controllers/api/v1/profiles_controller.rb
@@ -26,6 +26,6 @@ class Api::V1::ProfilesController < ApplicationController
   private
 
   def default_params
-    [:name, :bio, :x_twitter, :instagram, :facebook, :linkedin, :tiktok, :youtube, :website, :avatar_url]
+    [:name, :bio, :x_twitter, :instagram, :facebook, :linkedin, :tiktok, :youtube, :website, :avatar]
   end
 end

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::UsersController < ApplicationController
             :tiktok,
             :youtube,
             :website,
-            :avatar_url
+            :avatar
           ]
         }
       }

--- a/backend/app/models/profile.rb
+++ b/backend/app/models/profile.rb
@@ -13,20 +13,20 @@ class Profile < ApplicationRecord
                       format: { with: Constants::Regexps::YOUTUBE }
   validates :website, length: { maximum: 255 },
                       format: { with: Constants::Regexps::URL }
-  validates :avatar_url, length: { maximum: 4096 },
-                         format: { with: Constants::Regexps::URL }
-  validate :validate_avatar_url_extension
+  validates :avatar, length: { maximum: 4096 },
+                     format: { with: Constants::Regexps::URL }
+  validate :validate_avatar_extension
 
   private
 
-  def validate_avatar_url_extension
-    return if avatar_url.blank?
+  def validate_avatar_extension
+    return if avatar.blank?
 
     img_types = %w[jpg jpeg png gif webp]
-    extension = File.extname(avatar_url).delete('.')
+    extension = File.extname(avatar).delete('.')
     return if extension.blank?
     return if img_types.include?(extension)
 
-    errors.add(:avatar_url, I18n.t('errors.messages.wrong_img_extension'))
+    errors.add(:avatar, I18n.t('errors.messages.wrong_img_extension'))
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ApplicationRecord
           password: User.auto_create_password
         )
         user.create_provider!(kind: Provider.kinds[oauth2_params[:provider]], uid:)
-        user.create_profile!(name: oauth2_params[:name], avatar_url: oauth2_params[:picture])
+        user.create_profile!(name: oauth2_params[:name], avatar: oauth2_params[:picture])
       end
       user
     end

--- a/backend/config/locales/models/ja.yml
+++ b/backend/config/locales/models/ja.yml
@@ -21,7 +21,7 @@ ja:
         tiktok: TikTokのユーザ名
         youtube: YouTubeのユーザ名
         website: ウェブサイトのURL
-        avatar_url: プロフィール画像
+        avatar: プロフィール画像
       book:
         title: タイトル
         img_url: 画像のURL
@@ -55,7 +55,7 @@ ja:
           attributes:
             website:
               invalid: が不正な形式です
-            avatar_url:
+            avatar:
               invalid: が不正な形式です
             tiktok:
               invalid: は先頭の@不要です

--- a/backend/db/migrate/20240517095333_rename_avatar_url_column_to_profiles.rb
+++ b/backend/db/migrate/20240517095333_rename_avatar_url_column_to_profiles.rb
@@ -1,0 +1,5 @@
+class RenameAvatarUrlColumnToProfiles < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :profiles, :avatar_url, :avatar
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_13_053814) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_17_095333) do
   create_table "books", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.string "img_url", default: "", null: false
@@ -50,7 +50,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_053814) do
     t.string "website", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "avatar_url", default: "", null: false
+    t.string "avatar", default: "", null: false
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/backend/spec/factories/profile.rb
+++ b/backend/spec/factories/profile.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     tiktok { 'neumann-1903' }
     youtube { 'neumann-1903' }
     website { 'https://neuman.com' }
-    avatar_url { 'https://lh4.googleusercontent.com/photo.jpg' }
+    avatar { 'https://lh4.googleusercontent.com/photo.jpg' }
   end
 end

--- a/backend/spec/models/profile_spec.rb
+++ b/backend/spec/models/profile_spec.rb
@@ -251,32 +251,32 @@ RSpec.describe Profile do
       end
     end
 
-    context 'avatar_url' do
+    context 'avatar' do
       it '登録可能' do
-        expect(profile.avatar_url).to eq('https://lh4.googleusercontent.com/photo.jpg')
+        expect(profile.avatar).to eq('https://lh4.googleusercontent.com/photo.jpg')
       end
 
       it '通常のURL形式登録可能' do
-        profile.update!(avatar_url: 'https://lh4.googleusercontent.com/user_profile', user:)
-        expect(profile.avatar_url).to eq('https://lh4.googleusercontent.com/user_profile')
+        profile.update!(avatar: 'https://lh4.googleusercontent.com/user_profile', user:)
+        expect(profile.avatar).to eq('https://lh4.googleusercontent.com/user_profile')
       end
 
       it '暗号化されていないURLは登録不可' do
-        expect { profile.update!(avatar_url: 'http://lh4.googleusercontent.com/photo.jpg', user:) }.to(raise_error do |error|
+        expect { profile.update!(avatar: 'http://lh4.googleusercontent.com/photo.jpg', user:) }.to(raise_error do |error|
           expect(error).to be_a(ActiveRecord::RecordInvalid)
           expect(error.message).to eq('プロフィール画像が不正な形式です')
         end)
       end
 
       it '不正な形式は登録不可' do
-        expect { profile.update!(avatar_url: 'https://-@{}$$%%&&[]#', user:) }.to(raise_error do |error|
+        expect { profile.update!(avatar: 'https://-@{}$$%%&&[]#', user:) }.to(raise_error do |error|
           expect(error).to be_a(ActiveRecord::RecordInvalid)
           expect(error.message).to eq('プロフィール画像が不正な形式です')
         end)
       end
 
       it '画像以外の形式は登録不可' do
-        expect { profile.update!(avatar_url: 'https://lh4.googleusercontent.com/photo.pdf', user:) }.to(raise_error do |error|
+        expect { profile.update!(avatar: 'https://lh4.googleusercontent.com/photo.pdf', user:) }.to(raise_error do |error|
           expect(error).to be_a(ActiveRecord::RecordInvalid)
           expect(error.message).to eq('プロフィール画像の拡張子をjpg, jpeg, png, gif, webpにしてください')
         end)
@@ -284,17 +284,17 @@ RSpec.describe Profile do
 
       it 'nilの場合エラー' do
         expect do
-          profile.update(avatar_url: nil, user:)
+          profile.update(avatar: nil, user:)
         end.to raise_error(ActiveRecord::NotNullViolation)
       end
 
       it '空文字入力可能' do
-        profile.update(avatar_url: '', user:)
-        expect(profile.avatar_url).to eq('')
+        profile.update(avatar: '', user:)
+        expect(profile.avatar).to eq('')
       end
 
-      it 'avatar_urlのURLが4097文字以上の場合エラー' do
-        profile.update(avatar_url: 'a' * 4097, user:)
+      it 'avatarのURLが4097文字以上の場合エラー' do
+        profile.update(avatar: 'a' * 4097, user:)
         expect(profile).not_to be_valid
         expect(profile.errors.full_messages.first).to eq('プロフィール画像は4096文字以内で入力してください')
       end

--- a/backend/spec/requests/api/v1/profiles_controller_spec.rb
+++ b/backend/spec/requests/api/v1/profiles_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Api::V1::ProfilesController do
         expect(json['tiktok']).to eq('neumann-1903')
         expect(json['youtube']).to eq('neumann-1903')
         expect(json['website']).to eq('https://neuman.com')
-        expect(json['avatar_url']).to eq('https://lh4.googleusercontent.com/photo.jpg')
+        expect(json['avatar']).to eq('https://lh4.googleusercontent.com/photo.jpg')
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe Api::V1::ProfilesController do
         expect(json['tiktok']).to eq('hiroki-1998')
         expect(json['youtube']).to eq('hiroki_1998')
         expect(json['website']).to eq('https://hiroki.com')
-        expect(json['avatar_url']).to eq('https://lh4.googleusercontent.com/photo.jpg')
+        expect(json['avatar']).to eq('https://lh4.googleusercontent.com/photo.jpg')
       end
     end
 

--- a/backend/spec/requests/api/v1/users_controller_spec.rb
+++ b/backend/spec/requests/api/v1/users_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::UsersController do
         expect(json['profile']['tiktok']).to eq('neumann-1903')
         expect(json['profile']['youtube']).to eq('neumann-1903')
         expect(json['profile']['website']).to eq('https://neuman.com')
-        expect(json['profile']['avatar_url']).to eq('https://lh4.googleusercontent.com/photo.jpg')
+        expect(json['profile']['avatar']).to eq('https://lh4.googleusercontent.com/photo.jpg')
       end
 
       it 'ログインユーザ自身が別のユーザ詳細を取得しようとしても自身が返る' do

--- a/frontend/neumann-client/src/app/(main)/(public)/users/[slug]/layout.tsx
+++ b/frontend/neumann-client/src/app/(main)/(public)/users/[slug]/layout.tsx
@@ -73,11 +73,11 @@ export default async function ProfileLayout({ children, params }: { children: Re
     <section className='space-y-8'>
       <div className='md:flex  md:space-x-4 md:space-y-0 space-y-4'>
         <div className='w-16 h-16 flex justify-center items-center rounded-lg shadow sub-bg-color text-xs font-medium text-center dark:border dark:border-gray-600'>
-          {res.avatar_url ? (
+          {res.avatar ? (
             <Image
               width={64}
               height={64}
-              src={res.avatar_url}
+              src={res.avatar}
               alt={`${res.name}のプロフィール画像`}
               sizes='
                         50vw,

--- a/frontend/neumann-client/src/components/common/Header/Avatar.tsx
+++ b/frontend/neumann-client/src/components/common/Header/Avatar.tsx
@@ -66,11 +66,11 @@ export default function Avatar() {
             onClick={handleClick}
             className='w-12 h-12 rounded-lg shadow sub-bg-color text-xs font-medium text-center dark:border dark:border-gray-600'
           >
-            {user.profile.avatar_url ? (
+            {user.profile.avatar ? (
               <Image
                 width={48}
                 height={48}
-                src={user.profile.avatar_url}
+                src={user.profile.avatar}
                 alt={`${user.profile.name}のプロフィール画像`}
                 sizes='
                           50vw,

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/profile.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/profile.ts
@@ -14,7 +14,7 @@ type Response = {
   tiktok: string
   youtube: string
   website: string
-  avatar_url: string
+  avatar: string
 }
 
 type UpdateParams = {

--- a/frontend/neumann-client/src/types/user.ts
+++ b/frontend/neumann-client/src/types/user.ts
@@ -11,6 +11,6 @@ export type User = {
     tiktok: string
     youtube: string
     website: string
-    avatar_url: string
+    avatar: string
   }
 }


### PR DESCRIPTION
### やりたかったこと

profileテーブルのavatar_urlカラム名をavatarに変更

### やったこと

- マイグレーションファイルを作成（実行したコマンド：rails g migration rename_avatar_url_column_to_profiles）
- avatar_urlが使われいる箇所をavatarに変更

### やらなかったこと

特になし

### ユーザ視点での変更

特になし

### 影響範囲

avatar_urlが使用されていた箇所、プロフィールupdateコントローラー、Oauth2でプロフィール画像を設定する箇所、プロフィール画像を表示する箇所（メニューボタン、ユーザプロフィール）

### 動作確認観点
 - [x] RSpec
 - [x] メニューボタン、プロフィールページ動作確認

### issue


### その他
