### PR TITLE
fix: Content-Typeのデフォルト指定廃止

### DIFF
--- a/frontend/neumann-client/src/lib/wrappedFeatch/index.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/index.ts
@@ -29,7 +29,6 @@ function buildFullPath(baseURL: string, requestedURL: string): string {
 /** リクエストヘッダを構築する */
 function buildHeaders<T = HeadersInit>(headers?: T): HeadersInit {
   const defaultHeaders = {
-    'Content-Type': 'application/json',
     'X-Requested-With': 'XMLHttpRequest',
   }
 

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/account.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/account.ts
@@ -22,7 +22,10 @@ type UpdateParams = {
 export async function patchUserAccount(updateData: AccountUpdateData, accessToken: string) {
   const params = { user: updateData }
   return await fetch.patch<UpdateParams, Response>('/api/v1/users', params, {
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
     credentials: 'include',
   })
 }

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/googleOauth2.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/googleOauth2.ts
@@ -19,7 +19,12 @@ type Oauth2Params = {
 
 export async function postGoogleOuth2(oauth2Data: Oauth2Data) {
   const params = { oauth2: oauth2Data }
-  return await fetch.post<Oauth2Params, ResponseToken>('/api/v1/google_oauth2', params, { credentials: 'include' })
+  return await fetch.post<Oauth2Params, ResponseToken>('/api/v1/google_oauth2', params, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  })
 }
 
 export async function googleOauth2AuthorizationUrl() {

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/like.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/like.ts
@@ -26,7 +26,10 @@ export async function getLike(bookId: BookDetail['id'], accessToken: AccessToken
 export async function postLike(bookLikeData: BookLikeData, accessToken: AccessToken) {
   const params = { book: bookLikeData }
   return await fetch.post<BookLikeParams, Response>('/api/v1/likes', params, {
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
     credentials: 'include',
   })
 }

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/login.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/login.ts
@@ -15,5 +15,10 @@ type LoginParams = {
 
 export async function postAuthToken(loginData: LoginData) {
   const params = { auth: loginData }
-  return await fetch.post<LoginParams, Response>('/api/v1/auth_token', params, { credentials: 'include' })
+  return await fetch.post<LoginParams, Response>('/api/v1/auth_token', params, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  })
 }

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/refreshToken.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/refreshToken.ts
@@ -18,6 +18,9 @@ export async function refreshToken(accessToken: AccessToken) {
   // ローカルストレージに過去にログインした形跡がある場合、そしてアクセストークンがないサイレントリフレッシュ
   if (!accessToken)
     return await fetch.post<null, Response>('/api/v1/auth_token/refresh', null, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
       credentials: 'include',
     })
 
@@ -28,6 +31,9 @@ export async function refreshToken(accessToken: AccessToken) {
   if (!exp || isValidExp(exp)) return
 
   return await fetch.post<null, Response>('/api/v1/auth_token/refresh', null, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
     credentials: 'include',
   })
 }

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/signup.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/signup.ts
@@ -16,5 +16,10 @@ type SignupParams = {
 
 export async function postUserCreate(signupData: SignupData) {
   const params = { user: signupData }
-  return await fetch.post<SignupParams, Response>('/api/v1/users', params, { credentials: 'include' })
+  return await fetch.post<SignupParams, Response>('/api/v1/users', params, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  })
 }


### PR DESCRIPTION
### やりたかったこと

new  FormData()のfetchを投げる際にブラウザが自動で設定したcontent-typeでリクエストを飛ばす

### やったこと

- デフォルトで指定されていた 'Content-Type': 'application/json' を取り除いた
- 各リクエストでjsonオブジェクトをfetchするリクエストのみに 'Content-Type': 'application/json' を指定するように変更

### やらなかったこと

- new  FormData()をfetchするリクエストに対して'Content-Type': 'multipart/form-data' の指定（これを手動でやるとサーバサイドでエラーが発生するのでcontent-typeを指定せずにブラウザに付けてもらう）

### ユーザ視点での変更

特になし

### 影響範囲

*各リクエスト*

 - ユーザ新規作成（email・password）
 - サイレントリフレッシュ
 - ログアウト
 - ログイン（email・password）
 - 書籍一覧ページ・書籍詳細（サーバサイド）
 - 書籍いいね、いいね解除
 - ユーザいいねページ一覧
 - メールアドレス・パスワード変更
 - ユーザ詳細（サーバサイド）
 - アカウント削除
 - google認証・認証用URL取得

### 動作確認観点

*ブラウザ側から各リクエストが飛ぶ操作を行った*

 - [x] ユーザ新規作成（email・password）
 - [x] サイレントリフレッシュ
 - [x] ログアウト
 - [x] ログイン（email・password）
 - [x] 書籍一覧ページ・書籍詳細（サーバサイド）
 - [x] 書籍いいね、いいね解除
 - [x] ユーザいいねページ一覧
 - [x] メールアドレス・パスワード変更
 - [x] ユーザ詳細（サーバサイド）
 - [x] アカウント削除
 - [x] google認証・認証用URL取得

### issue

### その他
