### PR TITLE
fix: 書籍データのリクエスト失敗時に再度取り込みが行えるようにする

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "jest",
     "start": "npx ts-node -r tsconfig-paths/register src/index.ts",
-    "dev": "npx ts-node -r tsconfig-paths/register src/amazonBookScraping/index.ts"
+    "dev": "npx ts-node -r tsconfig-paths/register src/amazonBookScraping/index.ts",
+    "script": "npx ts-node -r tsconfig-paths/register src/script/scrapingResetAmazonLinks.ts"
   },
   "keywords": [],
   "author": "",

--- a/bot/src/amazonBookScraping/functions/bookInfo.ts
+++ b/bot/src/amazonBookScraping/functions/bookInfo.ts
@@ -162,7 +162,7 @@ export const getBookInfo = async (url: string) => {
   } catch (error) {
     console.error(error)
 
-    console.info(requestText.forceCloseScraping)
+    console.info(requestText.forceClosePuppeteer)
     await browser.close()
 
     return new PuppeteerError(requestText.errorScraping, url)

--- a/bot/src/amazonBookScraping/functions/bookInfo.ts
+++ b/bot/src/amazonBookScraping/functions/bookInfo.ts
@@ -1,4 +1,4 @@
-import { NotBookError, PuppeteerError } from '@/lib/errors'
+import { NotBookError, PuppeteerError, ScrapingRequestError } from '@/lib/errors'
 import requestText from '@/text/request.json'
 import { getASIN } from '@/utils/amazon'
 import puppeteer, { type Page } from 'puppeteer'
@@ -21,6 +21,9 @@ type BookPagePath = (typeof PAGE_ELEMENT_PATH)[number]
 
 const PUBLISHER_ELEMENT_PATH = ['#rpi-attribute-book_details-publisher .rpi-attribute-value > span'] as const
 type PublisherPath = (typeof PUBLISHER_ELEMENT_PATH)[number]
+
+const isRequestFailed = async (page: Page) =>
+  await elementExists(page, 'form[method="get"][action="/errors/validateCaptcha"][name=""]')
 
 const isBook = async (page: Page) => {
   const breadcrumbs = await page.$$eval(
@@ -131,6 +134,8 @@ export const getBookInfo = async (url: string) => {
 
   try {
     await page.goto(url, { waitUntil: 'domcontentloaded' })
+    if (await isRequestFailed(page)) return new ScrapingRequestError(requestText.scrapingRequestError, url)
+
     if (!(await isBook(page))) {
       await browser.close()
 

--- a/bot/src/amazonBookScraping/index.ts
+++ b/bot/src/amazonBookScraping/index.ts
@@ -52,7 +52,6 @@ type BookInfo = {
 
 const COLLECTION_AMAZON_LINKS = 'amazonLinks'
 const COLLECTION_AMAZON_ERROR = 'amazonError'
-const COLLECTION_AMAZON_REQUEST_ERROR = 'amazonRequestError'
 const COLLECTION_NOT_BOOKS = 'notBooksLink'
 const COLLECTION_AMAZON_BOOKS = 'amazonBooks'
 const PAGE_LIMIT = 10
@@ -110,20 +109,12 @@ const storePuppeteerError = (bookInfo: PuppeteerError) => {
   )
 }
 
-const storeScrapingRequestError = (bookInfo: ScrapingRequestError, linkInfo: AmazonLinks) => {
-  const { message } = bookInfo
+const forceExsitScrapingRequestError = (bookInfo: ScrapingRequestError) => {
+  const { message, url } = bookInfo
+
   console.error(message)
-
-  const { productUrl, score, referenceObj, hashtags } = linkInfo
-  const scrapingRequestErrorObj = {
-    productUrl,
-    score,
-    referenceObj,
-    hashtags,
-    timeStamp: FieldValue.serverTimestamp(),
-  }
-
-  return storeObjOverWrite(generateDocRef(firestore, COLLECTION_AMAZON_REQUEST_ERROR), scrapingRequestErrorObj)
+  console.error(requestText.amazonRequestError, url)
+  process.exit(1)
 }
 
 const storeBook = async (bookInfo: BookInfo, linkInfo: AmazonLinks, id: AmazonObj['id']) => {
@@ -167,7 +158,7 @@ const batchAmazonLinksRequestStoreBook = async (amazonObjs: AmazonObj[]) => {
       bookObjs.map(bookObj => {
         const { id, bookInfo, linkInfo } = bookObj
 
-        if (bookInfo instanceof ScrapingRequestError) return storeScrapingRequestError(bookInfo, linkInfo)
+        if (bookInfo instanceof ScrapingRequestError) return forceExsitScrapingRequestError(bookInfo)
         if (bookInfo instanceof PuppeteerError) return storePuppeteerError(bookInfo)
         if (bookInfo instanceof NotBookError) return storeNotBookError(bookInfo, id)
 

--- a/bot/src/amazonBookScraping/index.ts
+++ b/bot/src/amazonBookScraping/index.ts
@@ -140,19 +140,23 @@ const storeBook = async (bookInfo: BookInfo, linkInfo: AmazonLinks, id: AmazonOb
   return amazonLinkScraped(id)
 }
 
+const generateAmazonObj = async (amazonObjs: AmazonObj[]) => {
+  return await Promise.all(
+    amazonObjs.map(async amazonObj => {
+      const { id, data } = amazonObj
+      return {
+        id,
+        bookInfo: await getBookInfo(data['productUrl']),
+        linkInfo: data,
+      }
+    }),
+  )
+}
+
 const batchAmazonLinksRequestStoreBook = async (amazonObjs: AmazonObj[]) => {
   const amazonObjChunk = chunkArray(amazonObjs, CHUNK_SIZE)
   for (const amazonObjs of amazonObjChunk) {
-    const bookObjs = await Promise.all(
-      amazonObjs.map(async amazonObj => {
-        const { id, data } = amazonObj
-        return {
-          id,
-          bookInfo: await getBookInfo(data['productUrl']),
-          linkInfo: data,
-        }
-      }),
-    )
+    const bookObjs = await generateAmazonObj(amazonObjs)
 
     await Promise.all(
       bookObjs.map(bookObj => {

--- a/bot/src/lib/errors/index.ts
+++ b/bot/src/lib/errors/index.ts
@@ -45,3 +45,16 @@ export class NotBookError extends AppError {
     this.url = url
   }
 }
+
+export class ScrapingRequestError extends AppError {
+  url: string
+
+  static {
+    this.prototype.name = 'ScrapingRequestError'
+  }
+
+  constructor(message: string, url: string, options?: ErrorOptions) {
+    super(message, options)
+    this.url = url
+  }
+}

--- a/bot/src/lib/fireStore/index.ts
+++ b/bot/src/lib/fireStore/index.ts
@@ -37,3 +37,18 @@ export const notScrapingQuery = (
 
   return firestore.collection(collectionName).where('scraping', '==', false).limit(limit)
 }
+export const limitQuery = (
+  firestore: Firestore,
+  collectionName: string,
+  lastDocument: QueryDocumentSnapshot | undefined,
+  limit: number,
+) => {
+  if (lastDocument) {
+    return firestore.collection(collectionName).limit(limit).startAfter(lastDocument)
+  }
+
+  return firestore.collection(collectionName).limit(limit)
+}
+
+export const scrapingRequestErrorQuery = (firestore: Firestore, collectionName: string, limit: number) =>
+  firestore.collection(collectionName).limit(limit)

--- a/bot/src/script/scrapingResetAmazonLinks.ts
+++ b/bot/src/script/scrapingResetAmazonLinks.ts
@@ -1,0 +1,59 @@
+import { limitQuery } from '@/lib/fireStore'
+import { generateDocRef, storeObjOverWrite } from '@/lib/fireStore'
+import requestText from '@/text/request.json'
+import { type DocumentData, Firestore, type QueryDocumentSnapshot, type QuerySnapshot } from '@google-cloud/firestore'
+
+const COLLECTION_AMAZON_LINKS = 'amazonLinks'
+const PAGE_LIMIT = 100
+
+const firestore = new Firestore()
+
+const getAmazonLinks = async (initialPage: QueryDocumentSnapshot | undefined) => {
+  const amazonLinks = await limitQuery(firestore, COLLECTION_AMAZON_LINKS, initialPage, PAGE_LIMIT).get()
+  if (!amazonLinks.empty) return amazonLinks
+
+  console.info(requestText.noAmazonLinks)
+}
+
+const scrapingStatusFalse = async (ids: string[]) => {
+  await Promise.all(
+    ids.map(id => {
+      console.info(requestText.amazonLinksReset, id)
+      return storeObjOverWrite(generateDocRef(firestore, COLLECTION_AMAZON_LINKS, id), {
+        scraping: false,
+      })
+    }),
+  )
+}
+
+const isReCrawling = (objSize: number) => PAGE_LIMIT <= objSize
+
+const extractAmazonLinksData = (amazonLinks: QuerySnapshot<DocumentData, DocumentData>) => {
+  const amazonLinksSize = amazonLinks.docs.length
+  const lastDocumentIndex = amazonLinksSize - 1
+  const nextPage = amazonLinks.docs[lastDocumentIndex]
+  const amazonLinksIds = amazonLinks.docs.map(doc => doc.id)
+
+  return { amazonLinksSize, nextPage, amazonLinksIds }
+}
+
+const resetScrapingStatus = async (initialPage: QueryDocumentSnapshot | undefined = undefined) => {
+  console.info(
+    requestText.startCrawling,
+    `Start from （AmazonLinksのscrapingをリセット） : ${initialPage ? initialPage.id : requestText.initialPage}`,
+  )
+
+  const amazonLinks = await getAmazonLinks(initialPage)
+  if (!amazonLinks) return
+  const { amazonLinksSize, nextPage, amazonLinksIds } = extractAmazonLinksData(amazonLinks)
+  await scrapingStatusFalse(amazonLinksIds)
+
+  if (isReCrawling(amazonLinksSize)) {
+    await resetScrapingStatus(nextPage)
+  } else {
+    console.info(requestText.doneAmazonLinksReset)
+  }
+}
+;(async () => {
+  await resetScrapingStatus()
+})()

--- a/bot/src/text/request.json
+++ b/bot/src/text/request.json
@@ -22,5 +22,6 @@
   "duplicateArticle": "記事keyの重複を確認",
   "scrapingRequestError": "商品ページのリクエストに失敗しました",
   "amazonLinksReset": "amazonLinksの取り込み設定をリセット",
-  "doneAmazonLinksReset": "amazonLinksのリセット完了"
+  "doneAmazonLinksReset": "amazonLinksのリセット完了",
+  "amazonRequestError": "取得制限のためリクエストに失敗しました"
 }

--- a/bot/src/text/request.json
+++ b/bot/src/text/request.json
@@ -19,5 +19,8 @@
   "asin": "こちらの商品を追加します",
   "noAsin": "ASINが取得出来ませんでした",
   "doneAmazonCrawling": "Amazon商品のクローリングが終了",
-  "duplicateArticle": "記事keyの重複を確認"
+  "duplicateArticle": "記事keyの重複を確認",
+  "scrapingRequestError": "商品ページのリクエストに失敗しました",
+  "amazonLinksReset": "amazonLinksの取り込み設定をリセット",
+  "doneAmazonLinksReset": "amazonLinksのリセット完了"
 }

--- a/bot/src/text/request.json
+++ b/bot/src/text/request.json
@@ -14,7 +14,7 @@
   "puppeteerClose": "書籍データ取得完了",
   "noAmazonLinks": "未取得のAmazonLinksがありません",
   "errorScraping": "スクレイピング中にエラー発生",
-  "forceCloseScraping": "スクレイピング強制停止",
+  "forceClosePuppeteer": "Puppeteer強制停止",
   "notBook": "商品URLが書籍ではないです",
   "asin": "こちらの商品を追加します",
   "noAsin": "ASINが取得出来ませんでした",


### PR DESCRIPTION
### やりたかったこと

~~書籍情報であるがリクエストが失敗して、書籍データを取得出来なかった物があるため
その際にFirestoreにエラー情報として保存し、再度取得出来るようにする~~

※ 再度、クローリングを実行した際にすでに取得される仕様になっていた
ScrapingRequestErrorが実行される際はamazonLinkScrapedが実行されないため AmazonLinks scraping: falseのままである
再度クローラを実行すれば取得する処理が走る

### やったこと

- AmazonLinksのscrapingステータスを未取得に変更するスクリプトを作成
- ScrapingRequestErrorが実行された際には処理を強制的に停止するように変更


### やらなかったこと

- ASINが取得出来ませんでしたの修正（https://www.amazon.co.jp/exec/obidos/ASIN/4799326686/opc-22/ref=nosim）このタイプのURLで発生している

### ユーザ視点での変更

登録される書籍の精度が上がる

### 影響範囲

Botのphase3

### 動作確認観点

 - [x] jestのテスト
 - [x] 手動での確認
 - [ ] 強制的に停止される処理確認

### issue

### その他

今回の変更箇所を修正する際に知っておいた方が良い事等ありましたら記載をお願いします。(この説明は記載する際に削除して下さい)
