### PR TITLE
feat: ユーザ数を集計する処理追加

### DIFF
--- a/backend/app/controllers/api/v1/user_analytics_controller.rb
+++ b/backend/app/controllers/api/v1/user_analytics_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::UserAnalyticsController < ApplicationController
+  # before_action :authenticate_request, only: [:create]
+
+  def index
+    user_analytics = UserAnalytic.order(created_at: :desc).limit(10)
+
+    render json: {
+      user_analytics: user_analytics.as_json(only: [:name, :count]),
+      user_total: UserAnalytic.user_total
+    }
+  end
+
+  def create
+    user_analytic = UserAnalytic.create!(
+      name: Time.zone.now.strftime('%m/%d'),
+      count: UserAnalytic.user_total
+    )
+    render status: :created, json: { user_analytic: user_analytic.as_json(only: [:name, :count]) }
+  end
+end

--- a/backend/app/controllers/concerns/http_response_concern.rb
+++ b/backend/app/controllers/concerns/http_response_concern.rb
@@ -41,4 +41,8 @@ module HttpResponseConcern
   def status_unprocessable_entity(message)
     render status: :unprocessable_entity, json: { error: { message: } }
   end
+
+  def unauthorized_request
+    render status: :unauthorized, json: { error: { message: I18n.t('errors.request.unauthorized_request') } }
+  end
 end

--- a/backend/app/models/user_analytic.rb
+++ b/backend/app/models/user_analytic.rb
@@ -1,0 +1,9 @@
+class UserAnalytic < ApplicationRecord
+  validates :name, format: { with: Constants::Regexps::MONTH_DAY }
+
+  class << self
+    def user_total
+      User.all.size
+    end
+  end
+end

--- a/backend/app/services/analytic/cron_request_auth.rb
+++ b/backend/app/services/analytic/cron_request_auth.rb
@@ -1,0 +1,43 @@
+require 'jwt'
+
+module Analytic
+  class CronRequestAuth
+    include TokenConcern
+
+    attr_reader :token
+
+    def initialize
+      @token = JWT.encode(claims, secret_key, algorithm, header_fields)
+    end
+
+    class << self
+      def valid_cron_request_jwt?(state)
+        payload = JWT.decode(state, secret_key, true, verify_claims).first
+        payload.with_indifferent_access[:iss].present?
+      rescue JWT::DecodeError
+        false
+      end
+
+      private
+
+      def verify_claims
+        {
+          iss:,
+          aud:,
+          verify_iss: true,
+          verify_aud: true,
+          algorithm:
+        }
+      end
+    end
+
+    private
+
+    def claims
+      {
+        iss:,
+        aud:
+      }
+    end
+  end
+end

--- a/backend/app/services/concerns/auth_concern.rb
+++ b/backend/app/services/concerns/auth_concern.rb
@@ -1,0 +1,8 @@
+module AuthConcern
+  private
+
+  # リクエストヘッダートークンを取得する
+  def token_from_request_headers
+    request.headers['Authorization']&.split&.last
+  end
+end

--- a/backend/app/services/concerns/user_auth_concern.rb
+++ b/backend/app/services/concerns/user_auth_concern.rb
@@ -1,4 +1,6 @@
 module UserAuthConcern
+  include AuthConcern
+
   private
 
   def delete_session

--- a/backend/app/services/user_auth/authenticate_service.rb
+++ b/backend/app/services/user_auth/authenticate_service.rb
@@ -10,11 +10,6 @@ module UserAuth
 
     private
 
-    # リクエストヘッダートークンを取得する
-    def token_from_request_headers
-      request.headers['Authorization']&.split&.last
-    end
-
     # access_tokenから有効なユーザーを取得する
     def fetch_user_from_access_token
       User.from_access_token(token_from_request_headers)

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -131,6 +131,7 @@ ja:
       not_image_file: 画像ファイル以外をアップロードしないでください。
       less_512kb: 画像ファイルは512KB以下にしてください。
       can_not_change_password_user_google: Google認証ユーザはパスワード変更不可です。
+      unauthorized_request: 不正なリクエストです。
   helpers:
     select:
       prompt: 選択してください

--- a/backend/config/locales/models/ja.yml
+++ b/backend/config/locales/models/ja.yml
@@ -40,6 +40,9 @@ ja:
       note_reference:
         hashtags: ハッシュタグ
         reference_objs: 参照先
+      user_analytic:
+        name: 日付
+        count: ユーザー数
     errors:
       models:
         user:
@@ -82,4 +85,9 @@ ja:
           attributes:
             user_id:
               taken: はこの書籍をいいね済みです
+        user_analytic:
+          attributes:
+            name:
+              invalid: が不正な形式です
+
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
         resource :profiles, only: [:update]
         resources :profiles, only: [:show]
         resources :books, only: [:index, :show]
+        resources :user_analytics, only: [:index, :create]
         resources :google_oauth2, only: [:create] do
           post :authorization_url, on: :collection
         end

--- a/backend/db/migrate/20240802034054_create_user_analytics.rb
+++ b/backend/db/migrate/20240802034054_create_user_analytics.rb
@@ -1,0 +1,10 @@
+class CreateUserAnalytics < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_analytics do |t|
+      t.string :name, null: false, default: ''
+      t.integer :count, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_21_064042) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_02_034054) do
   create_table "books", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.text "img_url"
@@ -75,6 +75,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_21_064042) do
     t.datetime "updated_at", null: false
     t.index ["uid"], name: "index_providers_on_uid", unique: true
     t.index ["user_id"], name: "index_providers_on_user_id"
+  end
+
+  create_table "user_analytics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.integer "count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/backend/lib/constants/regexps.rb
+++ b/backend/lib/constants/regexps.rb
@@ -6,4 +6,5 @@ class Constants::Regexps
   TIKTOK = /\A([^@].*|)\z/
   YOUTUBE = /\A([^@].*|)\z/
   DATE = /\A\z|\A[1-9]\d{3}-\d{2}-\d{2}\z/
+  MONTH_DAY = %r{\A(0[1-9]|1[0-2])/(0[1-9]|[12]\d|3[01])\z}
 end

--- a/backend/spec/factories/user_analytics.rb
+++ b/backend/spec/factories/user_analytics.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_analytic do
+    name { '08/02' }
+    count { 100 }
+  end
+end

--- a/backend/spec/models/user_analytic_spec.rb
+++ b/backend/spec/models/user_analytic_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe UserAnalytic do
+  let(:user_analytic) { FactoryBot.build(:user_analytic) }
+  let(:user) { FactoryBot.create(:user) }
+
+  it '有効なファクトリを持つこと' do
+    expect(user_analytic).to be_valid
+  end
+
+  describe 'validation' do
+    context 'name' do
+      it '登録可能' do
+        expect(user_analytic.name).to eq('08/02')
+      end
+
+      it 'nilの場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: nil)
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '存在しない月の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '13/02')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '存在しない日の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '12/32')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '1桁の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '0/0')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '存在しない日付の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '00/00')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+    end
+
+    context 'count' do
+      it 'nilの場合エラー' do
+        expect do
+          user_analytic.update!(count: nil)
+        end.to raise_error(ActiveRecord::NotNullViolation)
+      end
+    end
+  end
+
+  describe 'methods' do
+    before do
+      user
+    end
+
+    context 'user_total' do
+      it '全ユーザ数が返る' do
+        expect(described_class.user_total).to eq(1)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/user_analytics_controller_spec.rb
+++ b/backend/spec/requests/api/v1/user_analytics_controller_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UserAnalyticsController do
+  include_context 'user_authorities'
+  let(:user_analytic) { FactoryBot.create(:user_analytic) }
+
+  describe 'GET #index' do
+    context '正常系' do
+      before do
+        11.times do |n|
+          time = Time.zone.now.ago(n.days)
+
+          FactoryBot.create(
+            :user_analytic,
+            name: Time.zone.now.ago(n.days).strftime('%m/%d'),
+            count: n,
+            created_at: time,
+            updated_at: time
+          )
+        end
+      end
+
+      it 'リクエスト成功、ステータスコード/200が返る' do
+        get api_v1_user_analytics_path, **headers
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '直近の10日分のユーザ数合計数と現在のユーザ数が取得される' do
+        get api_v1_user_analytics_path, **headers
+
+        json = response.parsed_body
+
+        expect(json.size).to eq(2)
+        expect(json['user_analytics'].size).to eq(10)
+        json['user_analytics'].each_with_index do |user_analytic, index|
+          expect(user_analytic['name']).to eq(Time.zone.now.ago(index.days).strftime('%m/%d'))
+        end
+        expect(json['user_total']).to eq(2)
+      end
+    end
+
+    context '異常系' do
+      it '登録が0場合でもデータ返る' do
+        get api_v1_user_analytics_path, **headers
+
+        json = response.parsed_body
+
+        expect(json.size).to eq(2)
+        expect(json['user_analytics'].size).to eq(0)
+        expect(json['user_total']).to eq(2)
+      end
+
+      it '登録が1件の場合でもデータ返る' do
+        user_analytic
+        get api_v1_user_analytics_path, **headers
+
+        json = response.parsed_body
+
+        expect(json.size).to eq(2)
+        expect(json['user_analytics'].size).to eq(1)
+        expect(json['user_total']).to eq(2)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context '正常系' do
+      it 'リクエストを受け取ると現在のユーザ数が集計される' do
+        post api_v1_user_analytics_path, **headers
+
+        expect(UserAnalytic.all.size).to eq 1
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+
+        expect(json.size).to eq(1)
+        expect(json['user_analytic']['name']).to eq(Time.zone.now.strftime('%m/%d'))
+        expect(json['user_analytic']['count']).to eq(2)
+      end
+    end
+  end
+end

--- a/backend/spec/services/analytic/cron_request_auth_spec.rb
+++ b/backend/spec/services/analytic/cron_request_auth_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Analytic::CronRequestAuth, type: :service do
+  describe 'CronRequestAuth' do
+    let!(:jwt) { described_class.new.token }
+
+    context 'token' do
+      it 'jwtトークンが発行される' do
+        expect(jwt).to be_present
+      end
+    end
+
+    context 'valid_cron_request_jwt?' do
+      it '検証が有効になる' do
+        expect(described_class.valid_cron_request_jwt?(jwt)).to be(true)
+      end
+
+      it '有効期限なし' do
+        travel_to(30.years.from_now) do
+          expect(described_class.valid_cron_request_jwt?(jwt)).to be(true)
+        end
+      end
+
+      context '異常系' do
+        it '検証が無効になる' do
+          expect(described_class.valid_cron_request_jwt?("#{jwt}_dummy_sub")).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### やりたかったこと

cronからリクエストを受け取り、ユーザ数を毎日集計して、直近の10件を返すAPIを建てる

### やったこと

- user_analyticsテーブルを作成
  - name（フロントエンドのチャートライブラリ - Recharts のデータ形式に合わせるためにnameというカラム名にしました）カラム追加 
  - countカラムを追加
- user_analyticsコントローラ追加
  - index：直近の10日間のユーザ数を返す
  - create：リクエストを受け取って現在時刻のユーザ数を作成、リクエストはjwt認証をパスする必要がある

### やらなかったこと

特になし

### ユーザ視点での変更

特になし

### 影響範囲

user_auth_concern

### 動作確認観点

 - [x] RSpecのテストパス

### issue


### その他
