### PR TITLE
feat: ユーザ数の増減をフッターに表示する

### DIFF
--- a/backend/app/controllers/api/v1/user_analytics_controller.rb
+++ b/backend/app/controllers/api/v1/user_analytics_controller.rb
@@ -1,0 +1,31 @@
+class Api::V1::UserAnalyticsController < ApplicationController
+  include AuthConcern
+  before_action :authenticate_request, only: [:create]
+
+  def index
+    user_analytics = UserAnalytic.order(created_at: :desc).limit(10)
+
+    render json: {
+      user_analytics: user_analytics.as_json(only: [:name, :count]),
+      user_total: UserAnalytic.user_total
+    }
+  end
+
+  def create
+    user_analytic = UserAnalytic.create!(
+      name: Time.zone.now.strftime('%m/%d'),
+      count: UserAnalytic.user_total
+    )
+
+    render status: :created, json: { user_analytic: user_analytic.as_json(only: [:name, :count]) }
+  end
+
+  private
+
+  def authenticate_request
+    jwt_token = token_from_request_headers
+    return unauthorized_request unless jwt_token
+
+    Analytic::CronRequestAuth.valid_cron_request_jwt?(jwt_token) || unauthorized_request
+  end
+end

--- a/backend/app/controllers/concerns/http_response_concern.rb
+++ b/backend/app/controllers/concerns/http_response_concern.rb
@@ -41,4 +41,8 @@ module HttpResponseConcern
   def status_unprocessable_entity(message)
     render status: :unprocessable_entity, json: { error: { message: } }
   end
+
+  def unauthorized_request
+    render status: :unauthorized, json: { error: { message: I18n.t('errors.request.unauthorized_request') } }
+  end
 end

--- a/backend/app/models/user_analytic.rb
+++ b/backend/app/models/user_analytic.rb
@@ -1,0 +1,9 @@
+class UserAnalytic < ApplicationRecord
+  validates :name, format: { with: Constants::Regexps::MONTH_DAY }
+
+  class << self
+    def user_total
+      User.all.size
+    end
+  end
+end

--- a/backend/app/services/analytic/cron_request_auth.rb
+++ b/backend/app/services/analytic/cron_request_auth.rb
@@ -1,0 +1,43 @@
+require 'jwt'
+
+module Analytic
+  class CronRequestAuth
+    include TokenConcern
+
+    attr_reader :token
+
+    def initialize
+      @token = JWT.encode(claims, secret_key, algorithm, header_fields)
+    end
+
+    class << self
+      def valid_cron_request_jwt?(state)
+        payload = JWT.decode(state, secret_key, true, verify_claims).first
+        payload.with_indifferent_access[:iss].present?
+      rescue JWT::DecodeError
+        false
+      end
+
+      private
+
+      def verify_claims
+        {
+          iss:,
+          aud:,
+          verify_iss: true,
+          verify_aud: true,
+          algorithm:
+        }
+      end
+    end
+
+    private
+
+    def claims
+      {
+        iss:,
+        aud:
+      }
+    end
+  end
+end

--- a/backend/app/services/concerns/auth_concern.rb
+++ b/backend/app/services/concerns/auth_concern.rb
@@ -1,0 +1,8 @@
+module AuthConcern
+  private
+
+  # リクエストヘッダートークンを取得する
+  def token_from_request_headers
+    request.headers['Authorization']&.split&.last
+  end
+end

--- a/backend/app/services/concerns/user_auth_concern.rb
+++ b/backend/app/services/concerns/user_auth_concern.rb
@@ -1,4 +1,6 @@
 module UserAuthConcern
+  include AuthConcern
+
   private
 
   def delete_session

--- a/backend/app/services/user_auth/authenticate_service.rb
+++ b/backend/app/services/user_auth/authenticate_service.rb
@@ -10,11 +10,6 @@ module UserAuth
 
     private
 
-    # リクエストヘッダートークンを取得する
-    def token_from_request_headers
-      request.headers['Authorization']&.split&.last
-    end
-
     # access_tokenから有効なユーザーを取得する
     def fetch_user_from_access_token
       User.from_access_token(token_from_request_headers)

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -131,6 +131,7 @@ ja:
       not_image_file: 画像ファイル以外をアップロードしないでください。
       less_512kb: 画像ファイルは512KB以下にしてください。
       can_not_change_password_user_google: Google認証ユーザはパスワード変更不可です。
+      unauthorized_request: 不正なリクエストです。
   helpers:
     select:
       prompt: 選択してください

--- a/backend/config/locales/models/ja.yml
+++ b/backend/config/locales/models/ja.yml
@@ -40,6 +40,9 @@ ja:
       note_reference:
         hashtags: ハッシュタグ
         reference_objs: 参照先
+      user_analytic:
+        name: 日付
+        count: ユーザー数
     errors:
       models:
         user:
@@ -82,4 +85,9 @@ ja:
           attributes:
             user_id:
               taken: はこの書籍をいいね済みです
+        user_analytic:
+          attributes:
+            name:
+              invalid: が不正な形式です
+
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
         resource :profiles, only: [:update]
         resources :profiles, only: [:show]
         resources :books, only: [:index, :show]
+        resources :user_analytics, only: [:index, :create]
         resources :google_oauth2, only: [:create] do
           post :authorization_url, on: :collection
         end

--- a/backend/db/migrate/20240802034054_create_user_analytics.rb
+++ b/backend/db/migrate/20240802034054_create_user_analytics.rb
@@ -1,0 +1,10 @@
+class CreateUserAnalytics < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_analytics do |t|
+      t.string :name, null: false, default: ''
+      t.integer :count, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_21_064042) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_02_034054) do
   create_table "books", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.text "img_url"
@@ -75,6 +75,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_21_064042) do
     t.datetime "updated_at", null: false
     t.index ["uid"], name: "index_providers_on_uid", unique: true
     t.index ["user_id"], name: "index_providers_on_user_id"
+  end
+
+  create_table "user_analytics", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.integer "count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/backend/lib/constants/regexps.rb
+++ b/backend/lib/constants/regexps.rb
@@ -6,4 +6,5 @@ class Constants::Regexps
   TIKTOK = /\A([^@].*|)\z/
   YOUTUBE = /\A([^@].*|)\z/
   DATE = /\A\z|\A[1-9]\d{3}-\d{2}-\d{2}\z/
+  MONTH_DAY = %r{\A(0[1-9]|1[0-2])/(0[1-9]|[12]\d|3[01])\z}
 end

--- a/backend/spec/factories/user_analytics.rb
+++ b/backend/spec/factories/user_analytics.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_analytic do
+    name { '08/02' }
+    count { 100 }
+  end
+end

--- a/backend/spec/models/user_analytic_spec.rb
+++ b/backend/spec/models/user_analytic_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe UserAnalytic do
+  let(:user_analytic) { FactoryBot.build(:user_analytic) }
+  let(:user) { FactoryBot.create(:user) }
+
+  it '有効なファクトリを持つこと' do
+    expect(user_analytic).to be_valid
+  end
+
+  describe 'validation' do
+    context 'name' do
+      it '登録可能' do
+        expect(user_analytic.name).to eq('08/02')
+      end
+
+      it 'nilの場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: nil)
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '存在しない月の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '13/02')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '存在しない日の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '12/32')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '1桁の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '0/0')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+
+      it '存在しない日付の場合エラー' do
+        u = FactoryBot.build(:user_analytic, name: '00/00')
+        expect(u).not_to be_valid
+        expect(u.errors.full_messages_for(:name).first).to eq('日付が不正な形式です')
+      end
+    end
+
+    context 'count' do
+      it 'nilの場合エラー' do
+        expect do
+          user_analytic.update!(count: nil)
+        end.to raise_error(ActiveRecord::NotNullViolation)
+      end
+    end
+  end
+
+  describe 'methods' do
+    before do
+      user
+    end
+
+    context 'user_total' do
+      it '全ユーザ数が返る' do
+        expect(described_class.user_total).to eq(1)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/user_analytics_controller_spec.rb
+++ b/backend/spec/requests/api/v1/user_analytics_controller_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UserAnalyticsController do
+  include_context 'user_authorities'
+  let(:user_analytic) { FactoryBot.create(:user_analytic) }
+  let!(:jwt) { Analytic::CronRequestAuth.new.token }
+  let(:headers_with_cron_request_token) { { headers: { 'X-Requested-With' => 'XMLHttpRequest', Authorization: "Bearer #{jwt}" } } }
+
+  describe 'GET #index' do
+    context '正常系' do
+      before do
+        11.times do |n|
+          time = Time.zone.now.ago(n.days)
+
+          FactoryBot.create(
+            :user_analytic,
+            name: Time.zone.now.ago(n.days).strftime('%m/%d'),
+            count: n,
+            created_at: time,
+            updated_at: time
+          )
+        end
+      end
+
+      it 'リクエスト成功、ステータスコード/200が返る' do
+        get api_v1_user_analytics_path, **headers
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '直近の10日分のユーザ数合計数と現在のユーザ数が取得される' do
+        get api_v1_user_analytics_path, **headers
+
+        json = response.parsed_body
+
+        expect(json.size).to eq(2)
+        expect(json['user_analytics'].size).to eq(10)
+        json['user_analytics'].each_with_index do |user_analytic, index|
+          expect(user_analytic['name']).to eq(Time.zone.now.ago(index.days).strftime('%m/%d'))
+        end
+        expect(json['user_total']).to eq(2)
+      end
+    end
+
+    context '異常系' do
+      it '登録が0場合でもデータ返る' do
+        get api_v1_user_analytics_path, **headers
+
+        json = response.parsed_body
+
+        expect(json.size).to eq(2)
+        expect(json['user_analytics'].size).to eq(0)
+        expect(json['user_total']).to eq(2)
+      end
+
+      it '登録が1件の場合でもデータ返る' do
+        user_analytic
+        get api_v1_user_analytics_path, **headers
+
+        json = response.parsed_body
+
+        expect(json.size).to eq(2)
+        expect(json['user_analytics'].size).to eq(1)
+        expect(json['user_total']).to eq(2)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    context '正常系' do
+      it 'リクエストを受け取ると現在のユーザ数が集計される' do
+        post api_v1_user_analytics_path, **headers_with_cron_request_token
+
+        expect(UserAnalytic.all.size).to eq 1
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+
+        expect(json.size).to eq(1)
+        expect(json['user_analytic']['name']).to eq(Time.zone.now.strftime('%m/%d'))
+        expect(json['user_analytic']['count']).to eq(2)
+      end
+    end
+
+    context '異常系' do
+      it 'トークンなしの場合エラーになる' do
+        post api_v1_user_analytics_path, **headers
+
+        expect(UserAnalytic.all.size).to eq 0
+        expect(response).to have_http_status(:unauthorized)
+        json = response.parsed_body
+
+        expect(json.size).to eq(1)
+        expect(json['error']['message']).to eq('不正なリクエストです。')
+      end
+    end
+  end
+end

--- a/backend/spec/services/analytic/cron_request_auth_spec.rb
+++ b/backend/spec/services/analytic/cron_request_auth_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Analytic::CronRequestAuth, type: :service do
+  describe 'CronRequestAuth' do
+    let!(:jwt) { described_class.new.token }
+
+    context 'token' do
+      it 'jwtトークンが発行される' do
+        expect(jwt).to be_present
+      end
+    end
+
+    context 'valid_cron_request_jwt?' do
+      it '検証が有効になる' do
+        expect(described_class.valid_cron_request_jwt?(jwt)).to be(true)
+      end
+
+      it '有効期限なし' do
+        travel_to(30.years.from_now) do
+          expect(described_class.valid_cron_request_jwt?(jwt)).to be(true)
+        end
+      end
+
+      context '異常系' do
+        it '検証が無効になる' do
+          expect(described_class.valid_cron_request_jwt?("#{jwt}_dummy_sub")).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/frontend/neumann-client/package-lock.json
+++ b/frontend/neumann-client/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.49.3",
+        "recharts": "^2.12.7",
         "remark": "^15.0.1",
         "remark-breaks": "^4.0.0",
         "remark-frontmatter": "^5.0.0",
@@ -654,7 +655,6 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
       "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1831,6 +1831,60 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2759,6 +2813,14 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2943,8 +3005,117 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -2981,6 +3152,11 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -3155,6 +3331,15 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -3325,6 +3510,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3393,6 +3583,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -3949,6 +4147,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -6043,8 +6249,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -7230,7 +7435,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7691,6 +7895,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -7793,6 +8012,35 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+      "integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7814,6 +8062,41 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
+      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^16.10.2",
+        "react-smooth": "^4.0.0",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7830,8 +8113,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
@@ -8650,6 +8932,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -9071,6 +9358,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/neumann-client/package.json
+++ b/frontend/neumann-client/package.json
@@ -20,6 +20,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.49.3",
+    "recharts": "^2.12.7",
     "remark": "^15.0.1",
     "remark-breaks": "^4.0.0",
     "remark-frontmatter": "^5.0.0",

--- a/frontend/neumann-client/src/components/common/Footer/UsersChart.tsx
+++ b/frontend/neumann-client/src/components/common/Footer/UsersChart.tsx
@@ -1,60 +1,38 @@
 'use client'
 
 import { useDarkMode } from '@/hooks/useDarkMode'
-import { Line, LineChart, ResponsiveContainer } from 'recharts'
-
-const data = [
-  {
-    name: 'Page A',
-    uv: 4000,
-    pv: 2400,
-    amt: 2400,
-  },
-  {
-    name: 'Page B',
-    uv: 3000,
-    pv: 1398,
-    amt: 2210,
-  },
-  {
-    name: 'Page C',
-    uv: 2000,
-    pv: 9800,
-    amt: 2290,
-  },
-  {
-    name: 'Page D',
-    uv: 2780,
-    pv: 3908,
-    amt: 2000,
-  },
-  {
-    name: 'Page E',
-    uv: 1890,
-    pv: 4800,
-    amt: 2181,
-  },
-  {
-    name: 'Page F',
-    uv: 2390,
-    pv: 3800,
-    amt: 2500,
-  },
-  {
-    name: 'Page G',
-    uv: 3490,
-    pv: 4300,
-    amt: 2100,
-  },
-]
+import { FetchError } from '@/lib/errors'
+import { getUserAnalytics } from '@/lib/wrappedFeatch/requests/analytic'
+import error from '@/text/error.json'
+import { Line, LineChart, ResponsiveContainer, YAxis } from 'recharts'
+import useSWR from 'swr'
 
 export default function UsersChart() {
   const isDarkMode = useDarkMode()
+  const { data } = useSWR('/api/v1/user_analytics', getUserAnalytics)
+
+  if (!data || data instanceof FetchError) {
+    return <p>{error.failedUserAnalyticsFetch}</p>
+  }
+
   return (
-    <ResponsiveContainer width='100%' height={112}>
-      <LineChart data={data}>
-        <Line type='monotone' dataKey='pv' stroke={isDarkMode ? '#F76E76' : '#FF0211'} strokeWidth={2} dot={false} />
-      </LineChart>
-    </ResponsiveContainer>
+    <>
+      <ul className='flex justify-between'>
+        <li>ユーザー数</li>
+        <li>{data.user_total}</li>
+      </ul>
+      <ResponsiveContainer width='100%' height={112}>
+        <LineChart data={data.user_analytics}>
+          <YAxis reversed hide />
+          <Line
+            type='monotone'
+            dataKey='count'
+            stroke={isDarkMode ? '#F76E76' : '#FF0211'}
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </>
   )
 }

--- a/frontend/neumann-client/src/components/common/Footer/UsersChart.tsx
+++ b/frontend/neumann-client/src/components/common/Footer/UsersChart.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useDarkMode } from '@/hooks/useDarkMode'
+import { Line, LineChart, ResponsiveContainer } from 'recharts'
+
+const data = [
+  {
+    name: 'Page A',
+    uv: 4000,
+    pv: 2400,
+    amt: 2400,
+  },
+  {
+    name: 'Page B',
+    uv: 3000,
+    pv: 1398,
+    amt: 2210,
+  },
+  {
+    name: 'Page C',
+    uv: 2000,
+    pv: 9800,
+    amt: 2290,
+  },
+  {
+    name: 'Page D',
+    uv: 2780,
+    pv: 3908,
+    amt: 2000,
+  },
+  {
+    name: 'Page E',
+    uv: 1890,
+    pv: 4800,
+    amt: 2181,
+  },
+  {
+    name: 'Page F',
+    uv: 2390,
+    pv: 3800,
+    amt: 2500,
+  },
+  {
+    name: 'Page G',
+    uv: 3490,
+    pv: 4300,
+    amt: 2100,
+  },
+]
+
+export default function UsersChart() {
+  const isDarkMode = useDarkMode()
+  return (
+    <ResponsiveContainer width='100%' height={112}>
+      <LineChart data={data}>
+        <Line type='monotone' dataKey='pv' stroke={isDarkMode ? '#F76E76' : '#FF0211'} strokeWidth={2} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/neumann-client/src/components/common/Footer/index.tsx
+++ b/frontend/neumann-client/src/components/common/Footer/index.tsx
@@ -54,10 +54,6 @@ export default function Footer() {
             </div>
             <div className='lg:max-w-40 max-w-28 w-full space-y-5'>
               <div className='font-bold'>User</div>
-              <ul className='flex justify-between'>
-                <li>現在のユーザ数</li>
-                <li>25600</li>
-              </ul>
               <DynamicUsersChart />
             </div>
           </div>

--- a/frontend/neumann-client/src/components/common/Footer/index.tsx
+++ b/frontend/neumann-client/src/components/common/Footer/index.tsx
@@ -1,6 +1,9 @@
 import app from '@/text/app.json'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import BizRankIcon from '../icon/BizRankIcon'
+
+const DynamicUsersChart = dynamic(() => import('./UsersChart'), { ssr: false })
 
 export default function Footer() {
   return (
@@ -55,6 +58,7 @@ export default function Footer() {
                 <li>現在のユーザ数</li>
                 <li>25600</li>
               </ul>
+              <DynamicUsersChart />
             </div>
           </div>
         </div>

--- a/frontend/neumann-client/src/hooks/useDarkMode.ts
+++ b/frontend/neumann-client/src/hooks/useDarkMode.ts
@@ -1,0 +1,15 @@
+import { isDarkMode as isDarkModeFn } from '@/utils/darkMode'
+import { useEffect, useState } from 'react'
+
+export const useDarkMode = () => {
+  const [isDarkMode, setIsDarkMode] = useState(isDarkModeFn())
+
+  useEffect(() => {
+    const updateSettingColor = () => setIsDarkMode(isDarkModeFn())
+    matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateSettingColor)
+
+    return () => window.removeEventListener('change', updateSettingColor)
+  }, [])
+
+  return isDarkMode
+}

--- a/frontend/neumann-client/src/lib/wrappedFeatch/requests/analytic.ts
+++ b/frontend/neumann-client/src/lib/wrappedFeatch/requests/analytic.ts
@@ -1,0 +1,17 @@
+import * as fetch from '@/lib/wrappedFeatch'
+
+type analytic = {
+  name: string
+  count: number
+}
+
+type ResponseAnalytic = {
+  user_analytics: analytic[]
+  user_total: number
+}
+
+export async function getUserAnalytics() {
+  return await fetch.get<ResponseAnalytic>('/api/v1/user_analytics', {
+    credentials: 'include',
+  })
+}

--- a/frontend/neumann-client/src/text/error.json
+++ b/frontend/neumann-client/src/text/error.json
@@ -8,5 +8,6 @@
   "failedBookFetchMetadata": "書籍詳細メタデータ取得に失敗しました。",
   "failedProfileFetchMetadata": "ユーザープロフィールのメタデータ取得に失敗しました。",
   "failedUserProfileNameMetadata": "ユーザープロフィール名のメタデータ取得に失敗しました。",
-  "failedUserLikesFetchMetadata": "ユーザーいいね一覧のメタデータ取得に失敗しました。"
+  "failedUserLikesFetchMetadata": "ユーザーいいね一覧のメタデータ取得に失敗しました。",
+  "failedUserAnalyticsFetch": "ユーザー数取得に失敗しました。"
 }


### PR DESCRIPTION
### やりたかったこと

フッターに現在のユーザ数を表示する

### やったこと

- ユーザ数を表示するコンポーネント作成
- ユーザ数を集計・返すAPi作成（認証機能付き）


### やらなかったこと

- 定期的にリクエストを投げるcronの設定、GCPのサービスCloud Scheduler等で設定してheaderに発行したjwtを含める

### ユーザ視点での変更

直近のユーザ数、増減を確認できる

### 影響範囲

リファクタリングを行ったのでuser_auth_concern、フッターコンポーネント

### 動作確認観点

 - [x] RSpecのテストパス
 - [x] PC・モバイル・タブレットでの表示確認
   - [x] リクエスト成功
   - [x] リクエスト失敗
 - [x] cURLでAPIに対してリクエストを投げてユーザ数が集計されるか確認   

### issue


### その他

