### PR TITLE
fix: 参照記事の説明場所変更

### DIFF
--- a/frontend/neumann-client/src/components/detail/NoteReference/index.tsx
+++ b/frontend/neumann-client/src/components/detail/NoteReference/index.tsx
@@ -10,10 +10,11 @@ export default function NoteReference({ referenceObjs }: NoteReferenceProps) {
   const ICON_SIZE = 16
 
   return (
-    <div className='text-gray-500 space-y-2'>
-      <ul className='space-y-4'>
+    <div className='space-y-8 text-sm'>
+      <span>書籍が紹介されていた記事</span>
+      <ul className='space-y-4 text-gray-500'>
         {referenceObjs.map(referenceObj => (
-          <li key={referenceObj.title} className='text-sm'>
+          <li key={referenceObj.title}>
             <div className='flex space-x-2'>
               <a className='hover:opacity-70' href={referenceObj.url} target='_blank' rel='nofollow'>
                 {referenceObj.title}
@@ -41,7 +42,6 @@ export default function NoteReference({ referenceObjs }: NoteReferenceProps) {
           </li>
         ))}
       </ul>
-      <span className='text-xs flex justify-end'>書籍が紹介されていた記事</span>
     </div>
   )
 }


### PR DESCRIPTION
### やりたかったこと

情報のフローを自然する
参照記事が多い場合、説明が画面外に行ってしまうので、ユーザが何のリンクなのかわからなくなるため
位置を変更したかった

### やったこと

- 書籍が紹介されていた記事の場所を移動

### やらなかったこと

特になし

### ユーザ視点での変更

情報のフローが自然となり何のリンクが分かりやすくなる

### 影響範囲

書籍詳細

### 動作確認観点

 - [x] 表示確認

### issue
https://github.com/wimpykid719/neumann/issues/25

### その他
