### PR TITLE
chore: 環境構築軽微な修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,51 @@ BizRankでは開発時に[vscode-run-rspec-file](https://marketplace.visualstudi
 
 下記の設定をするとRSpecファイルの好きな行で `cmd + ctr + l` を入力する事で素早くRSpecを実行して動作確認を行う事ができます。
 
+vscode-run-rspec-fileのショートカット設定
+```json:keybindings.json
+// Place your key bindings in this file to override the defaults
+[
+    {
+        "command": "extension.runLineOnRspec",
+        "key": "ctrl+cmd+l",
+        "when": "editorLangId == 'ruby'"
+    },
+    {
+        "command": "extension.runAllOpenedFiles",
+        "key": "cmd+alt+j",
+        "when": "editorLangId == 'ruby'"
+    },
+    {
+        "command": "extension.runFileOnRspec",
+        "key": "cmd+alt+l",
+        "when": "editorLangId == 'ruby'"
+    },
+    {
+        "command": "extension.runOpenSpec", // and toggle between files
+        "key": "cmd+alt+o",
+        "when": "editorLangId == 'ruby'"
+    },
+    {
+        "command": "extension.runOnLastSpec",
+        "key": "cmd+y",
+        "when": "editorLangId == 'ruby'"
+    },
+    {
+        "key": "cmd+l",
+        "command": "-extension.runLineOnRspec",
+        "when": "editorLangId == 'ruby'"
+    },
+    {
+        "key": "cmd+j",
+        "command": "workbench.action.tasks.runTask",
+        "args": "Run Jest on Current File"
+    }
+]
+```
+
+コンテナ内のRSpecでテストを実行する設定
 ```json:settings.json
-"vscode-run-rspec-file.custom-command": "docker exec -it backend-rails-api bundle exec rspec",
+"vscode-run-rspec-file.custom-command": "docker exec -it backend-rails-api bundle exec rspec --color",
 "vscode-run-rspec-file.folder": "backend/spec",
 ```
 

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -12,6 +12,11 @@ if [ ! -e "/frontend/package.json" ]; then
   cd neumann-client
 fi
 
+if [ ! -d "/frontend/node_modules" ]; then
+  echo 'frontendの開発環境構築'
+  npm install
+fi
+
 if [ ! -d "/frontend/neumann-client/node_modules" ]; then
   echo 'neumann-clientの環境構築'
   cd neumann-client


### PR DESCRIPTION
### やりたかったこと

フロントエンドの環境構築する際にBiomeがインストールされるようにする
ドキュメントの整備

### やったこと

- フロントエンドのentrypointでBiomeがインストールされるように処理追加
- vscode-run-rspec-fileの設定をドキュメントに追加


### やらなかったこと

特になし

### ユーザ視点での変更

特になし

### 影響範囲

特になし

### 動作確認観点

 - [x] git cloneしてBiomeがインストールされる事を確認
 - [x] ドキュメント通り環境構築してフロントエンド・バックエンドの環境構築
   - [x]  RSpecをショートカットから1行単位で実行出来る事を確認

### issue


### その他

今回の変更箇所を修正する際に知っておいた方が良い事等ありましたら記載をお願いします。(この説明は記載する際に削除して下さい)
